### PR TITLE
Fix token API network connection issue on Railway

### DIFF
--- a/client/src/lib/tokenApi.ts
+++ b/client/src/lib/tokenApi.ts
@@ -12,7 +12,7 @@ import type {
   ApiUsageMetrics,
 } from '../../../shared/schema';
 
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000';
+const API_BASE_URL = '';
 
 class TokenApiError extends Error {
   constructor(


### PR DESCRIPTION
- Change API_BASE_URL from localhost:5000 to relative URLs
- Makes tokenApi consistent with rest of application
- Resolves "Network error: Unable to connect to the API server"

🤖 Generated with [Claude Code](https://claude.ai/code)