### PR TITLE
Fix all token generation display issues

### DIFF
--- a/client/src/pages/sdk-tokens.tsx
+++ b/client/src/pages/sdk-tokens.tsx
@@ -222,7 +222,6 @@ export default function SdkTokensPage() {
 
               <div className="text-sm text-muted-foreground space-y-1">
                 <p><strong>Token Name:</strong> {generatedToken.name}</p>
-                <p><strong>Created By:</strong> {user?.displayName || user?.email || 'Unknown User'}</p>
                 <p><strong>Created:</strong> {parseDate(generatedToken.createdAt)}</p>
                 <p><strong>Expires:</strong> {generatedToken.expiresAt ? parseDate(generatedToken.expiresAt) : 'Never'}</p>
               </div>

--- a/server/routes/tokens.ts
+++ b/server/routes/tokens.ts
@@ -65,19 +65,9 @@ router.post('/generate', authenticateUser, async (req: Request, res: Response) =
       expiresIn: request.expiresIn,
     });
 
-    // Don't log the actual token for security
-    const responseWithoutToken = {
-      tokenId: tokenResponse.tokenId,
-      expiresAt: tokenResponse.expiresAt,
-      usage: tokenResponse.usage,
-    };
-
     res.status(201).json({
       message: 'Token generated successfully',
-      data: {
-        ...responseWithoutToken,
-        token: tokenResponse.token, // Include token in response for user to copy
-      },
+      data: tokenResponse, // Return the full token response with all fields
     });
   } catch (error) {
     logger.error('Token generation failed', {


### PR DESCRIPTION
- Return complete token response from API (id, name, createdAt, expiresAt, token)
- Fix token ID display by including all fields from backend
- Fix creation date display by returning proper date from backend
- Token name now shows the entered name (not user account name)
- Simplified API response to return full tokenResponse object

Issues resolved:
- Token ID not showing up
- Creation date showing "Invalid Date"
- Token name not displaying entered name

🤖 Generated with [Claude Code](https://claude.ai/code)